### PR TITLE
feat(openai_compat): add provider for /completions

### DIFF
--- a/birdie_snapshots/openai_compat_encode_request_preserves_reasoning_context.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_preserves_reasoning_context.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request preserves reasoning context
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_preserves_reasoning_context_across_turns_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"First question"},{"role":"assistant","content":"First answer","reasoning_content":"Reasoning one"},{"role":"user","content":"Second question"},{"role":"assistant","content":"Second answer","reasoning_content":"Reasoning two"},{"role":"user","content":"Follow up"}],"reasoning_effort":"high"}

--- a/birdie_snapshots/openai_compat_encode_request_preserves_thinking_history.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_preserves_thinking_history.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request preserves thinking history
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_context_send_with_tags_preserves_history_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"First question"},{"role":"assistant","content":"<think>Old reasoning</think>First answer"},{"role":"user","content":"Second question"},{"role":"assistant","content":"Second answer"},{"role":"user","content":"Follow up"}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_context_send_as_field.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_context_send_as_field.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with context send as field
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_context_send_as_field_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"First question"},{"role":"assistant","content":"First answer"},{"role":"user","content":"Follow up"}],"reasoning_effort":"high"}

--- a/birdie_snapshots/openai_compat_encode_request_with_context_send_with_tags.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_context_send_with_tags.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with context send with tags
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_context_send_with_tags_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"First question\nWith detail"},{"role":"assistant","content":"First answer with \"quotes\""},{"role":"user","content":"Follow up"}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_conversation.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_conversation.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with conversation
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_conversation_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi!"},{"role":"user","content":"How are you?"}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_disable_reasoning.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_disable_reasoning.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with disable_reasoning
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_disable_reasoning_test
+---
+{"model":"glm-z1-air","messages":[{"role":"user","content":"Quick answer"}],"disable_reasoning":true}

--- a/birdie_snapshots/openai_compat_encode_request_with_json_schema.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_json_schema.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with json schema
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_json_schema_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"Tell me about France"}],"response_format":{"type":"json_schema","json_schema":{"name":"response","schema":{"type":"object","properties":{"name":{"type":"string"}}}}}}

--- a/birdie_snapshots/openai_compat_encode_request_with_options.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_options.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with options
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_options_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}],"temperature":0.7,"max_tokens":1000}

--- a/birdie_snapshots/openai_compat_encode_request_with_reasoning_effort_high.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_reasoning_effort_high.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with reasoning_effort high
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_reasoning_effort_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"Solve step by step"}],"reasoning_effort":"high"}

--- a/birdie_snapshots/openai_compat_encode_request_with_reasoning_format_parsed.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_reasoning_format_parsed.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with reasoning_format parsed
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_reasoning_format_test
+---
+{"model":"llama-3.3-70b","messages":[{"role":"user","content":"Solve step by step"}],"reasoning_format":"parsed"}

--- a/birdie_snapshots/openai_compat_encode_request_with_system_prompt.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_system_prompt.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with system prompt
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_system_prompt_test
+---
+{"model":"gpt-4o","messages":[{"role":"system","content":"Be helpful"},{"role":"user","content":"Hello"}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_tool_calls.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_tool_calls.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with tool calls
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_tool_calls_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"What's the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_123","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_tool_result.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_tool_result.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with tool result
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_tool_result_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"What's the weather in Paris?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_123","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},{"role":"tool","tool_call_id":"call_123","name":"get_weather","content":"{\"temp\":22,\"condition\":\"sunny\"}"}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_tools.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_tools.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with tools
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_tools_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"What's the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}

--- a/birdie_snapshots/openai_compat_encode_request_with_zai_thinking_enabled.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_with_zai_thinking_enabled.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request with zai thinking enabled
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_with_zai_thinking_test
+---
+{"model":"deepseek-reasoner","messages":[{"role":"user","content":"Think about this"}],"thinking":{"type":"enabled"}}

--- a/birdie_snapshots/openai_compat_encode_request_without_interleaved_thinking.accepted
+++ b/birdie_snapshots/openai_compat_encode_request_without_interleaved_thinking.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode request without interleaved thinking
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_request_without_interleaved_thinking_omits_history_test
+---
+{"model":"deepseek-r1","messages":[{"role":"user","content":"First question"},{"role":"assistant","content":"First answer"},{"role":"user","content":"Follow up"}],"reasoning_effort":"high"}

--- a/birdie_snapshots/openai_compat_encode_simple_request.accepted
+++ b/birdie_snapshots/openai_compat_encode_simple_request.accepted
@@ -1,0 +1,7 @@
+---
+version: 1.5.3
+title: openai_compat encode simple request
+file: ./test/starlet/openai_compat_test.gleam
+test_name: encode_simple_request_test
+---
+{"model":"gpt-4o","messages":[{"role":"user","content":"Hello"}]}

--- a/src/starlet/openai_compat.gleam
+++ b/src/starlet/openai_compat.gleam
@@ -1,0 +1,715 @@
+//// OpenAI-compatible provider for starlet.
+////
+//// Uses the standard [Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create)
+//// (`/v1/chat/completions`) which is supported by many inference providers.
+////
+//// ## Usage
+////
+//// ```gleam
+//// import starlet
+//// import starlet/openai_compat
+//// import starlet/openai_compat/thinking
+////
+//// let client = openai_compat.new(
+////   "https://api.together.xyz/v1",
+////   api_key,
+////   thinking.Together,
+//// )
+////
+//// starlet.chat(client, "meta-llama/Llama-3-70b-chat-hf")
+//// |> starlet.user("Hello!")
+//// |> starlet.send()
+//// ```
+////
+//// ## Reasoning Support
+////
+//// For reasoning-capable models, use `with_reasoning`:
+////
+//// ```gleam
+//// starlet.chat(client, "deepseek-r1")
+//// |> openai_compat.with_reasoning(thinking.EffortHigh)
+//// |> starlet.user("Solve step by step...")
+//// |> starlet.send()
+//// ```
+////
+//// The dialect (set at client creation) determines how reasoning is
+//// encoded in requests and decoded from responses.
+////
+//// ## Provider Compatibility
+////
+//// This module works with any provider implementing the OpenAI Chat Completions
+//// API, including Synthetic, Together AI, Fireworks, Groq, vLLM, llama.cpp, and others.
+////
+
+import gleam/dynamic
+import gleam/dynamic/decode
+import gleam/http
+import gleam/http/request
+import gleam/httpc
+import gleam/json.{type Json}
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+import gleam/uri
+import starlet.{
+  type Chat, type Client, type Message, type Request, type Response,
+  type StarletError, type Turn, AssistantMessage, Chat, ProviderConfig, Response,
+  ToolResultMessage, UserMessage,
+}
+import starlet/internal/http as internal_http
+import starlet/openai_compat/thinking
+import starlet/tool
+
+/// OpenAI-compatible provider extension type.
+@internal
+pub type Ext {
+  Ext(
+    /// Provider dialect for encoding/decoding reasoning.
+    dialect: thinking.Dialect,
+    /// Active thinking configuration (derived from dialect + effort).
+    thinking_config: Option(thinking.Config),
+    /// Thinking content extracted from the last response.
+    thinking: Option(String),
+    /// Thinking content per assistant message index.
+    thinking_by_index: List(#(Int, String)),
+    /// Whether to preserve thinking across turns in message history.
+    interleaved_thinking: Bool,
+  )
+}
+
+/// Creates a new OpenAI-compatible client.
+///
+/// The base URL should include the API version path if needed, e.g.:
+/// - `"https://api.together.xyz/v1"`
+/// - `"https://api.fireworks.ai/inference/v1"`
+/// - `"http://localhost:8000/v1"` (for local vLLM)
+///
+/// The dialect determines how reasoning is encoded/decoded for this provider.
+pub fn new(
+  base_url: String,
+  api_key: String,
+  dialect: thinking.Dialect,
+) -> Client(Ext) {
+  let config =
+    ProviderConfig(
+      name: "openai_compat",
+      base_url: base_url,
+      send: fn(req, ext) { send_request(api_key, base_url, req, ext) },
+    )
+  let default_ext =
+    Ext(
+      dialect: dialect,
+      thinking_config: None,
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+  starlet.from_provider(config, default_ext)
+}
+
+/// Enable reasoning with the specified effort level.
+///
+/// The dialect (set at client creation) determines how this is encoded
+/// in the request and how reasoning is extracted from the response.
+///
+/// ```gleam
+/// starlet.chat(client, "deepseek-r1")
+/// |> openai_compat.with_reasoning(thinking.EffortHigh)
+/// |> starlet.user("Solve step by step...")
+/// |> starlet.send()
+/// ```
+pub fn with_reasoning(
+  chat: Chat(t, f, s, Ext),
+  effort: thinking.Effort,
+) -> Chat(t, f, s, Ext) {
+  let config = thinking.config_for_dialect(chat.ext.dialect, effort)
+  Chat(..chat, ext: Ext(..chat.ext, thinking_config: Some(config)))
+}
+
+/// Advanced: Enable reasoning with a custom configuration.
+///
+/// Use this for edge cases or unsupported providers. Most users should
+/// use `with_reasoning()` instead.
+///
+/// ```gleam
+/// import starlet/openai_compat/thinking
+/// let config = thinking.Config(
+///   request: thinking.RequestEffort("high"),
+///   response: thinking.ResponseFields(["reasoning_content"]),
+///   context: thinking.ContextDoNotSend,
+///   strip_from_content: False,
+/// )
+///
+/// starlet.chat(client, "some-model")
+/// |> openai_compat.with_thinking_config(config)
+/// |> starlet.user("...")
+/// |> starlet.send()
+/// ```
+pub fn with_thinking_config(
+  chat: Chat(t, f, s, Ext),
+  config: thinking.Config,
+) -> Chat(t, f, s, Ext) {
+  Chat(..chat, ext: Ext(..chat.ext, thinking_config: Some(config)))
+}
+
+/// Interleaved thinking is enabled by default. If enabled, Starlet
+/// preserves the reasoning content per-turn and relays it to the
+/// provider on subsequent turns. This is mostly helpful/necessary for
+/// open-weights models like GLM and Kimi.
+///
+/// Disable it with `without_interleaved_thinking` on subsequent turns.
+pub fn with_interleaved_thinking(chat: Chat(t, f, s, Ext)) -> Chat(t, f, s, Ext) {
+  Chat(..chat, ext: Ext(..chat.ext, interleaved_thinking: True))
+}
+
+/// Disable interleaved thinking in message history.
+pub fn without_interleaved_thinking(
+  chat: Chat(t, f, s, Ext),
+) -> Chat(t, f, s, Ext) {
+  Chat(..chat, ext: Ext(..chat.ext, interleaved_thinking: False))
+}
+
+/// Get the thinking/reasoning content from a turn (if present).
+pub fn thinking(turn: Turn(t, f, Ext)) -> Option(String) {
+  turn.ext.thinking
+}
+
+fn update_thinking_history(
+  ext: Ext,
+  req: Request,
+  thinking_content: Option(String),
+) -> Ext {
+  let base_ext = Ext(..ext, thinking: thinking_content)
+  case ext.interleaved_thinking, thinking_content {
+    True, Some(thinking_text) -> {
+      let index = list.length(req.messages)
+      let updated = [#(index, thinking_text), ..ext.thinking_by_index]
+      Ext(..base_ext, thinking_by_index: updated)
+    }
+    _, _ -> base_ext
+  }
+}
+
+fn thinking_for_message(
+  ext: Ext,
+  last_assistant: Option(Int),
+  index: Int,
+) -> Option(String) {
+  case ext.interleaved_thinking {
+    False ->
+      case last_assistant {
+        Some(last_index) if last_index == index -> ext.thinking
+        _ -> None
+      }
+    True ->
+      list.find(ext.thinking_by_index, fn(entry) {
+        let #(entry_index, _) = entry
+        entry_index == index
+      })
+      |> option.from_result
+      |> option.map(fn(entry) {
+        let #(_, text) = entry
+        text
+      })
+  }
+}
+
+fn send_request(
+  api_key: String,
+  base_url: String,
+  req: Request,
+  ext: Ext,
+) -> Result(#(Response, Ext), StarletError) {
+  let body = json.to_string(encode_request(req, ext))
+
+  case uri.parse(base_url) {
+    Ok(base_uri) -> {
+      let scheme = case option.unwrap(base_uri.scheme, "https") {
+        "http" -> http.Http
+        _ -> http.Https
+      }
+      let host = option.unwrap(base_uri.host, "localhost")
+      let base_path = base_uri.path
+
+      let http_request =
+        request.new()
+        |> request.set_method(http.Post)
+        |> request.set_scheme(scheme)
+        |> request.set_host(host)
+        |> internal_http.set_optional_port(base_uri.port)
+        |> request.set_path(base_path <> "/chat/completions")
+        |> request.set_header("content-type", "application/json")
+        |> request.set_header("authorization", "Bearer " <> api_key)
+        |> request.set_body(body)
+
+      let config = httpc.configure() |> httpc.timeout(req.timeout_ms)
+      case httpc.dispatch(config, http_request) {
+        Ok(response) ->
+          case response.status {
+            200 ->
+              case decode_response(response.body, ext) {
+                Ok(#(resp, thinking_content)) -> {
+                  let new_ext =
+                    update_thinking_history(ext, req, thinking_content)
+                  Ok(#(resp, new_ext))
+                }
+                Error(e) -> Error(e)
+              }
+            429 -> {
+              let retry_after =
+                internal_http.parse_retry_after(response.headers)
+              Error(starlet.RateLimited(retry_after))
+            }
+            status -> {
+              case decode_error_response(response.body) {
+                Ok(msg) ->
+                  Error(starlet.Provider(
+                    provider: "openai_compat",
+                    message: msg,
+                    raw: response.body,
+                  ))
+                Error(_) ->
+                  Error(starlet.Http(status: status, body: response.body))
+              }
+            }
+          }
+        Error(err) -> Error(starlet.Transport(string.inspect(err)))
+      }
+    }
+    Error(_) -> Error(starlet.Transport("Invalid base URL: " <> base_url))
+  }
+}
+
+fn decode_error_response(body: String) -> Result(String, Nil) {
+  let decoder = {
+    use error <- decode.field("error", {
+      use message <- decode.field("message", decode.string)
+      decode.success(message)
+    })
+    decode.success(error)
+  }
+  json.parse(body, decoder)
+  |> result.replace_error(Nil)
+}
+
+/// Encodes a request into JSON for the Chat Completions API.
+@internal
+pub fn encode_request(req: Request, ext: Ext) -> Json {
+  let messages = encode_messages(req.system_prompt, req.messages, ext)
+
+  let base = [
+    #("model", json.string(req.model)),
+    #("messages", json.array(messages, fn(m) { m })),
+  ]
+
+  let base = case req.tools {
+    [] -> base
+    _ -> list.append(base, [#("tools", encode_tools(req.tools))])
+  }
+
+  let base = case req.temperature {
+    Some(t) -> list.append(base, [#("temperature", json.float(t))])
+    None -> base
+  }
+
+  let base = case req.max_tokens {
+    Some(n) -> list.append(base, [#("max_tokens", json.int(n))])
+    None -> base
+  }
+
+  let base = case req.json_schema {
+    Some(schema) ->
+      list.append(base, [
+        #(
+          "response_format",
+          json.object([
+            #("type", json.string("json_schema")),
+            #(
+              "json_schema",
+              json.object([
+                #("name", json.string("response")),
+                #("schema", schema),
+              ]),
+            ),
+          ]),
+        ),
+      ])
+    None -> base
+  }
+
+  let base = encode_thinking_request(base, ext)
+
+  json.object(base)
+}
+
+fn encode_thinking_request(
+  base: List(#(String, Json)),
+  ext: Ext,
+) -> List(#(String, Json)) {
+  case ext.thinking_config {
+    None -> base
+    Some(config) ->
+      case config.request {
+        thinking.RequestNone -> base
+        thinking.RequestEffort(effort) ->
+          list.append(base, [#("reasoning_effort", json.string(effort))])
+        thinking.RequestFormat(format) ->
+          list.append(base, [#("reasoning_format", json.string(format))])
+        thinking.RequestDisable(disabled) ->
+          list.append(base, [#("disable_reasoning", json.bool(disabled))])
+        thinking.RequestZai(enabled) ->
+          list.append(base, [
+            #(
+              "thinking",
+              json.object([
+                #(
+                  "type",
+                  json.string(case enabled {
+                    True -> "enabled"
+                    False -> "disabled"
+                  }),
+                ),
+              ]),
+            ),
+          ])
+      }
+  }
+}
+
+fn encode_messages(
+  system_prompt: Option(String),
+  messages: List(Message),
+  ext: Ext,
+) -> List(Json) {
+  let system_msgs = case system_prompt {
+    Some(prompt) -> [
+      json.object([
+        #("role", json.string("system")),
+        #("content", json.string(prompt)),
+      ]),
+    ]
+    None -> []
+  }
+
+  let last_assistant = last_assistant_index(messages)
+  let chat_msgs =
+    encode_messages_acc(messages, [], ext, last_assistant, 0) |> list.reverse
+
+  list.append(system_msgs, chat_msgs)
+}
+
+fn encode_messages_acc(
+  messages: List(Message),
+  acc: List(Json),
+  ext: Ext,
+  last_assistant: Option(Int),
+  index: Int,
+) -> List(Json) {
+  case messages {
+    [] -> acc
+    [msg, ..rest] -> {
+      case msg {
+        UserMessage(content) -> {
+          let encoded =
+            json.object([
+              #("role", json.string("user")),
+              #("content", json.string(content)),
+            ])
+          encode_messages_acc(
+            rest,
+            [encoded, ..acc],
+            ext,
+            last_assistant,
+            index + 1,
+          )
+        }
+        AssistantMessage(content, tool_calls) -> {
+          let message_thinking =
+            thinking_for_message(ext, last_assistant, index)
+          let encoded =
+            encode_assistant_message(content, tool_calls, ext, message_thinking)
+          encode_messages_acc(
+            rest,
+            [encoded, ..acc],
+            ext,
+            last_assistant,
+            index + 1,
+          )
+        }
+        ToolResultMessage(call_id, name, content) -> {
+          let encoded =
+            json.object([
+              #("role", json.string("tool")),
+              #("tool_call_id", json.string(call_id)),
+              #("name", json.string(name)),
+              #("content", json.string(content)),
+            ])
+          encode_messages_acc(
+            rest,
+            [encoded, ..acc],
+            ext,
+            last_assistant,
+            index + 1,
+          )
+        }
+      }
+    }
+  }
+}
+
+fn last_assistant_index(messages: List(Message)) -> Option(Int) {
+  last_assistant_index_loop(messages, 0, None)
+}
+
+fn last_assistant_index_loop(
+  messages: List(Message),
+  index: Int,
+  last: Option(Int),
+) -> Option(Int) {
+  case messages {
+    [] -> last
+    [msg, ..rest] -> {
+      let last = case msg {
+        AssistantMessage(_, _) -> Some(index)
+        _ -> last
+      }
+      last_assistant_index_loop(rest, index + 1, last)
+    }
+  }
+}
+
+fn encode_assistant_message(
+  content: String,
+  tool_calls: List(tool.Call),
+  ext: Ext,
+  thinking_content: Option(String),
+) -> Json {
+  case tool_calls {
+    [] -> {
+      let base = [
+        #("role", json.string("assistant")),
+        #("content", json.string(content)),
+      ]
+      let base = add_thinking_context(base, ext, thinking_content)
+      json.object(base)
+    }
+    _ -> {
+      let tc =
+        list.map(tool_calls, fn(call) {
+          json.object([
+            #("id", json.string(call.id)),
+            #("type", json.string("function")),
+            #(
+              "function",
+              json.object([
+                #("name", json.string(call.name)),
+                #(
+                  "arguments",
+                  json.string(
+                    json.to_string(tool.dynamic_to_json(call.arguments)),
+                  ),
+                ),
+              ]),
+            ),
+          ])
+        })
+      let content_json = case content {
+        "" -> json.null()
+        _ -> json.string(content)
+      }
+      let base = [
+        #("role", json.string("assistant")),
+        #("content", content_json),
+        #("tool_calls", json.array(tc, fn(t) { t })),
+      ]
+      let base = add_thinking_context(base, ext, thinking_content)
+      json.object(base)
+    }
+  }
+}
+
+fn add_thinking_context(
+  base: List(#(String, Json)),
+  ext: Ext,
+  thinking_content: Option(String),
+) -> List(#(String, Json)) {
+  case ext.thinking_config, thinking_content {
+    Some(config), Some(thinking_content) ->
+      case config.context {
+        thinking.ContextDoNotSend -> base
+        thinking.ContextSendAsField(field_name) ->
+          list.append(base, [#(field_name, json.string(thinking_content))])
+        thinking.ContextSendWithTags -> {
+          case list.key_find(base, "content") {
+            Ok(content_json) -> {
+              let new_content =
+                "<think>"
+                <> thinking_content
+                <> "</think>"
+                <> get_json_string(content_json)
+              list.key_set(base, "content", json.string(new_content))
+            }
+            Error(_) ->
+              list.append(base, [
+                #(
+                  "content",
+                  json.string("<think>" <> thinking_content <> "</think>"),
+                ),
+              ])
+          }
+        }
+      }
+    _, _ -> base
+  }
+}
+
+fn get_json_string(j: Json) -> String {
+  let s = json.to_string(j)
+  case json.parse(s, decode.string) {
+    Ok(value) -> value
+    Error(_) -> s
+  }
+}
+
+fn encode_tools(tools: List(tool.Definition)) -> Json {
+  json.array(tools, fn(t) {
+    case t {
+      tool.Function(name, description, parameters) ->
+        json.object([
+          #("type", json.string("function")),
+          #(
+            "function",
+            json.object([
+              #("name", json.string(name)),
+              #("description", json.string(description)),
+              #("parameters", parameters),
+            ]),
+          ),
+        ])
+    }
+  })
+}
+
+/// Decodes a JSON response from the Chat Completions API.
+/// Returns the Response and any thinking content.
+@internal
+pub fn decode_response(
+  body: String,
+  ext: Ext,
+) -> Result(#(Response, Option(String)), StarletError) {
+  let arguments_decoder =
+    decode.one_of(
+      {
+        use s <- decode.then(decode.string)
+        case json.parse(s, decode.dynamic) {
+          Ok(dyn) -> decode.success(dyn)
+          Error(_) -> decode.failure(dynamic.nil(), "parsable json string")
+        }
+      },
+      or: [decode.dynamic],
+    )
+
+  let function_decoder = {
+    use name <- decode.field("name", decode.string)
+    use arguments <- decode.field("arguments", arguments_decoder)
+    decode.success(#(name, arguments))
+  }
+
+  let tool_call_decoder = {
+    use id <- decode.field("id", decode.string)
+    use function <- decode.field("function", function_decoder)
+    let #(name, arguments) = function
+    decode.success(tool.Call(id:, name:, arguments:))
+  }
+
+  let thinking_fields = get_thinking_fields(ext)
+
+  let nullable_tool_calls_decoder =
+    decode.optional(decode.list(tool_call_decoder))
+    |> decode.map(option.unwrap(_, []))
+
+  let message_decoder = {
+    use content <- decode.optional_field("content", "", decode.string)
+    use tool_calls <- decode.optional_field(
+      "tool_calls",
+      [],
+      nullable_tool_calls_decoder,
+    )
+    decode.success(#(content, tool_calls))
+  }
+
+  let choice_decoder = {
+    use #(text, tool_calls) <- decode.field("message", message_decoder)
+    decode.success(#(text, tool_calls))
+  }
+
+  let decoder = {
+    use choices <- decode.field("choices", decode.list(choice_decoder))
+    case list.first(choices) {
+      Ok(#(text, tool_calls)) -> decode.success(#(text, tool_calls))
+      Error(_) -> decode.success(#("", []))
+    }
+  }
+
+  case json.parse(body, decoder) {
+    Ok(#(text, tool_calls)) -> {
+      let thinking_from_fields =
+        extract_thinking_from_body(body, thinking_fields)
+      let #(final_text, thinking_result) =
+        process_thinking(text, thinking_from_fields, ext)
+      let response = Response(text: final_text, tool_calls: tool_calls)
+      Ok(#(response, thinking_result))
+    }
+    Error(err) ->
+      Error(starlet.Decode(
+        "Failed to decode OpenAI-compat response: " <> string.inspect(err),
+      ))
+  }
+}
+
+fn get_thinking_fields(ext: Ext) -> List(String) {
+  thinking.get_response_fields(ext.thinking_config)
+}
+
+fn extract_thinking_from_body(
+  body: String,
+  fields: List(String),
+) -> Option(String) {
+  case fields {
+    [] -> None
+    [field, ..rest] -> {
+      let decoder = {
+        use choices <- decode.field(
+          "choices",
+          decode.list({
+            use msg <- decode.field("message", {
+              use value <- decode.optional_field(field, None, {
+                use v <- decode.then(decode.string)
+                decode.success(Some(v))
+              })
+              decode.success(value)
+            })
+            decode.success(msg)
+          }),
+        )
+        case list.first(choices) {
+          Ok(Some(v)) -> decode.success(Some(v))
+          _ -> decode.success(None)
+        }
+      }
+      case json.parse(body, decoder) {
+        Ok(Some(v)) -> Some(v)
+        _ -> extract_thinking_from_body(body, rest)
+      }
+    }
+  }
+}
+
+fn process_thinking(
+  text: String,
+  thinking_from_fields: Option(String),
+  ext: Ext,
+) -> #(String, Option(String)) {
+  thinking.process(text, thinking_from_fields, ext.thinking_config)
+}

--- a/src/starlet/openai_compat/thinking.gleam
+++ b/src/starlet/openai_compat/thinking.gleam
@@ -1,0 +1,226 @@
+//// Thinking/reasoning configuration for OpenAI-compatible providers.
+////
+//// Most users should use `openai_compat.with_reasoning()` instead of
+//// this module directly. This module provides advanced configuration
+//// for edge cases or unsupported providers.
+
+import gleam/option.{type Option, None, Some}
+import gleam/string
+
+/// Provider dialect for OpenAI-compatible APIs.
+/// Each dialect knows how to encode reasoning requests and decode responses.
+pub type Dialect {
+  /// Generic: reasoning_effort param, reasoning_content response field
+  Generic
+  /// Together AI: reasoning_effort param, reasoning/reasoning_content fields
+  Together
+  /// Groq: reasoning_format param, reasoning field or think tags
+  Groq
+  /// Cerebras: reasoning_format param, reasoning field
+  Cerebras
+  /// Local llama.cpp/vLLM: no request param, reasoning_content field
+  LlamaCpp
+  /// Tags: no request param, parse <think> tags from content
+  Tags
+}
+
+/// Reasoning effort level.
+pub type Effort {
+  EffortNone
+  EffortLow
+  EffortMedium
+  EffortHigh
+}
+
+/// How to request thinking/reasoning from the provider.
+pub type Request {
+  /// Don't send any reasoning params
+  RequestNone
+  /// Send `reasoning_effort: "low"|"medium"|"high"`
+  RequestEffort(String)
+  /// Send `reasoning_format: "parsed"|"raw"|"hidden"`
+  RequestFormat(String)
+  /// Send `disable_reasoning: true|false`
+  RequestDisable(Bool)
+  /// Send `thinking: { type: "enabled"|"disabled" }` (Z.ai style)
+  RequestZai(Bool)
+}
+
+/// How to extract thinking from the response.
+pub type Response {
+  /// Don't look for thinking in the response
+  ResponseNone
+  /// Look for thinking in these message fields
+  ResponseFields(List(String))
+  /// Parse `<think>...</think>` tags from the content
+  ResponseThinkTags
+}
+
+/// How to include thinking in multi-turn context.
+pub type Context {
+  /// Don't include thinking in subsequent requests (default)
+  ContextDoNotSend
+  /// Include thinking as a JSON field on assistant messages
+  ContextSendAsField(String)
+  /// Embed thinking as `<think>...</think>` tags in message content
+  ContextSendWithTags
+}
+
+/// Advanced configuration for thinking/reasoning behavior.
+/// Most users should use `openai_compat.with_reasoning()` instead.
+pub type Config {
+  Config(
+    request: Request,
+    response: Response,
+    context: Context,
+    strip_from_content: Bool,
+  )
+}
+
+/// Build the appropriate config for a dialect and effort level.
+@internal
+pub fn config_for_dialect(dialect: Dialect, effort: Effort) -> Config {
+  case dialect {
+    Generic -> generic_effort_config(effort)
+    Together -> together_config(effort)
+    Groq -> groq_config(effort)
+    Cerebras -> cerebras_config(effort)
+    LlamaCpp -> llama_cpp_config(effort)
+    Tags -> tags_config(effort)
+  }
+}
+
+fn generic_effort_config(effort: Effort) -> Config {
+  Config(
+    request: case effort {
+      EffortNone -> RequestNone
+      EffortLow -> RequestEffort("low")
+      EffortMedium -> RequestEffort("medium")
+      EffortHigh -> RequestEffort("high")
+    },
+    response: ResponseFields(["reasoning_content"]),
+    context: ContextSendAsField("reasoning_content"),
+    strip_from_content: False,
+  )
+}
+
+fn together_config(effort: Effort) -> Config {
+  Config(
+    request: case effort {
+      EffortNone -> RequestNone
+      EffortLow -> RequestEffort("low")
+      EffortMedium -> RequestEffort("medium")
+      EffortHigh -> RequestEffort("high")
+    },
+    response: ResponseFields(["reasoning_content", "reasoning"]),
+    context: ContextSendAsField("reasoning_content"),
+    strip_from_content: False,
+  )
+}
+
+fn groq_config(effort: Effort) -> Config {
+  case effort {
+    EffortNone ->
+      Config(
+        request: RequestFormat("hidden"),
+        response: ResponseNone,
+        context: ContextDoNotSend,
+        strip_from_content: False,
+      )
+    _ ->
+      Config(
+        request: RequestFormat("parsed"),
+        response: ResponseFields(["reasoning"]),
+        context: ContextSendAsField("reasoning"),
+        strip_from_content: False,
+      )
+  }
+}
+
+fn cerebras_config(effort: Effort) -> Config {
+  case effort {
+    EffortNone ->
+      Config(
+        request: RequestFormat("hidden"),
+        response: ResponseNone,
+        context: ContextDoNotSend,
+        strip_from_content: False,
+      )
+    _ ->
+      Config(
+        request: RequestFormat("parsed"),
+        response: ResponseFields(["reasoning"]),
+        context: ContextSendAsField("reasoning"),
+        strip_from_content: False,
+      )
+  }
+}
+
+fn llama_cpp_config(_effort: Effort) -> Config {
+  Config(
+    request: RequestNone,
+    response: ResponseFields(["reasoning_content"]),
+    context: ContextSendAsField("reasoning_content"),
+    strip_from_content: False,
+  )
+}
+
+fn tags_config(_effort: Effort) -> Config {
+  Config(
+    request: RequestNone,
+    response: ResponseThinkTags,
+    context: ContextSendWithTags,
+    strip_from_content: True,
+  )
+}
+
+/// Get the list of fields to check for thinking content.
+@internal
+pub fn get_response_fields(config: Option(Config)) -> List(String) {
+  case config {
+    Some(Config(response: ResponseFields(fields), ..)) -> fields
+    _ -> []
+  }
+}
+
+/// Process text and extracted thinking based on config.
+/// Returns (final_text, thinking_content).
+@internal
+pub fn process(
+  text: String,
+  thinking_from_fields: Option(String),
+  config: Option(Config),
+) -> #(String, Option(String)) {
+  case config {
+    None -> #(text, None)
+    Some(cfg) ->
+      case thinking_from_fields {
+        Some(thinking) -> #(text, Some(thinking))
+        None ->
+          case cfg.response {
+            ResponseThinkTags -> parse_think_tags(text, cfg.strip_from_content)
+            _ -> #(text, None)
+          }
+      }
+  }
+}
+
+/// Parse <think>...</think> tags from text.
+@internal
+pub fn parse_think_tags(text: String, strip: Bool) -> #(String, Option(String)) {
+  case string.split_once(text, "<think>") {
+    Ok(#(before, after_open)) ->
+      case string.split_once(after_open, "</think>") {
+        Ok(#(thinking_content, after_close)) -> {
+          let thinking = Some(string.trim(thinking_content))
+          let final_text = case strip {
+            True -> string.trim(before <> after_close)
+            False -> text
+          }
+          #(final_text, thinking)
+        }
+        Error(_) -> #(text, None)
+      }
+    Error(_) -> #(text, None)
+  }
+}

--- a/test/integration/fireworks_test.gleam
+++ b/test/integration/fireworks_test.gleam
@@ -1,0 +1,175 @@
+import envoy
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{Some}
+import gleam/result
+import gleam/string
+import jscheam/schema
+import starlet
+import starlet/openai_compat
+import starlet/openai_compat/thinking
+import starlet/tool
+import unitest
+
+pub fn simple_chat_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("FIREWORKS_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.fireworks.ai/inference/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let chat =
+    starlet.chat(client, "accounts/fireworks/models/kimi-k2-thinking")
+    |> starlet.system("Reply with exactly one word.")
+    |> starlet.user("Say hello")
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let response = starlet.text(turn)
+
+  assert string.length(response) > 0
+}
+
+pub fn tool_calling_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("FIREWORKS_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.fireworks.ai/inference/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let weather_tool =
+    tool.function(
+      name: "get_weather",
+      description: "Get the current weather for a city",
+      parameters: json.object([
+        #("type", json.string("object")),
+        #(
+          "properties",
+          json.object([
+            #(
+              "city",
+              json.object([
+                #("type", json.string("string")),
+                #("description", json.string("The city name")),
+              ]),
+            ),
+          ]),
+        ),
+        #("required", json.array(["city"], json.string)),
+      ]),
+    )
+
+  let chat =
+    starlet.chat(client, "accounts/fireworks/models/kimi-k2-thinking")
+    |> openai_compat.with_reasoning(thinking.EffortMedium)
+    |> starlet.system(
+      "You are a helpful assistant. Use the get_weather tool when asked about weather.",
+    )
+    |> starlet.with_tools([weather_tool])
+    |> starlet.user("What is the weather in Paris?")
+
+  let assert Ok(starlet.ToolCall(chat:, turn: _, calls:)) = starlet.step(chat)
+  let assert [call] = calls
+  assert call.name == "get_weather"
+
+  let tool_result =
+    tool.success(
+      call,
+      json.object([
+        #("temperature", json.int(22)),
+        #("condition", json.string("sunny")),
+      ]),
+    )
+  let chat = starlet.with_tool_results(chat, [tool_result])
+
+  let assert Ok(starlet.Done(chat: _, turn:)) = starlet.step(chat)
+  let response = starlet.text(turn)
+
+  assert string.length(response) > 0
+}
+
+pub fn json_output_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("FIREWORKS_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.fireworks.ai/inference/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let person_schema =
+    schema.object([
+      schema.prop("name", schema.string()),
+      schema.prop("age", schema.integer()),
+      schema.prop("city", schema.string()),
+    ])
+    |> schema.disallow_additional_props()
+
+  let chat =
+    starlet.chat(client, "accounts/fireworks/models/kimi-k2-thinking")
+    |> starlet.system(
+      "You are a helpful assistant that extracts structured data.",
+    )
+    |> starlet.with_json_output(person_schema)
+    |> starlet.user(
+      "Extract the person info: John Smith is 30 years old and lives in Paris.",
+    )
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let json_string = starlet.json(turn)
+
+  let person_decoder = {
+    use name <- decode.field("name", decode.string)
+    use age <- decode.field("age", decode.int)
+    use city <- decode.field("city", decode.string)
+    decode.success(#(name, age, city))
+  }
+
+  let assert Ok(#(name, age, city)) = json.parse(json_string, person_decoder)
+  assert name == "John Smith"
+  assert age == 30
+  assert city == "Paris"
+}
+
+pub fn reasoning_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("FIREWORKS_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.fireworks.ai/inference/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let chat =
+    starlet.chat(client, "accounts/fireworks/models/kimi-k2-thinking")
+    |> openai_compat.with_reasoning(thinking.EffortMedium)
+    |> starlet.user("What is the sum of all prime numbers between 1 and 20?")
+
+  let assert Ok(#(chat, turn1)) = starlet.send(chat)
+  let response1 = starlet.text(turn1)
+
+  assert string.length(response1) > 0
+  let assert Some(_) = openai_compat.thinking(turn1)
+
+  let chat =
+    chat
+    |> starlet.user("Now multiply that result by 3.")
+
+  let assert Ok(#(_chat, turn2)) = starlet.send(chat)
+  let response2 = starlet.text(turn2)
+
+  assert string.length(response2) > 0
+  let assert Some(_) = openai_compat.thinking(turn2)
+  Nil
+}

--- a/test/integration/run_openai_compat.gleam
+++ b/test/integration/run_openai_compat.gleam
@@ -1,0 +1,33 @@
+import gleam/io
+import integration/fireworks_test
+import integration/synthetic_test
+import integration/together_test
+
+pub fn main() {
+  io.println("fireworks: simple_chat_test")
+  fireworks_test.simple_chat_test()
+  io.println("fireworks: tool_calling_test")
+  fireworks_test.tool_calling_test()
+  io.println("fireworks: json_output_test")
+  fireworks_test.json_output_test()
+  io.println("fireworks: reasoning_test")
+  fireworks_test.reasoning_test()
+
+  io.println("synthetic: simple_chat_test")
+  synthetic_test.simple_chat_test()
+  io.println("synthetic: json_output_test")
+  synthetic_test.json_output_test()
+  io.println("synthetic: reasoning_test")
+  synthetic_test.reasoning_test()
+
+  io.println("together: simple_chat_test")
+  together_test.simple_chat_test()
+  io.println("together: tool_calling_test")
+  together_test.tool_calling_test()
+  io.println("together: json_output_test")
+  together_test.json_output_test()
+  io.println("together: reasoning_test")
+  together_test.reasoning_test()
+
+  io.println("✓ All tests passed!")
+}

--- a/test/integration/synthetic_test.gleam
+++ b/test/integration/synthetic_test.gleam
@@ -1,0 +1,112 @@
+import envoy
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{Some}
+import gleam/result
+import gleam/string
+import jscheam/schema
+import starlet
+import starlet/openai_compat
+import starlet/openai_compat/thinking
+import unitest
+
+pub fn simple_chat_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("SYNTHETIC_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.synthetic.new/openai/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let chat =
+    starlet.chat(client, "hf:moonshotai/Kimi-K2-Thinking")
+    |> starlet.system("Reply with exactly one word.")
+    |> starlet.user("Say hello")
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let response = starlet.text(turn)
+
+  assert string.length(response) > 0
+}
+
+pub fn json_output_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("SYNTHETIC_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.synthetic.new/openai/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let person_schema =
+    schema.object([
+      schema.prop("name", schema.string()),
+      schema.prop("age", schema.integer()),
+      schema.prop("city", schema.string()),
+    ])
+    |> schema.disallow_additional_props()
+
+  let chat =
+    starlet.chat(client, "hf:moonshotai/Kimi-K2-Thinking")
+    |> starlet.system(
+      "You are a helpful assistant that extracts structured data.",
+    )
+    |> starlet.with_json_output(person_schema)
+    |> starlet.user(
+      "Extract the person info: John Smith is 30 years old and lives in Paris.",
+    )
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let json_string = starlet.json(turn)
+
+  let person_decoder = {
+    use name <- decode.field("name", decode.string)
+    use age <- decode.field("age", decode.int)
+    use city <- decode.field("city", decode.string)
+    decode.success(#(name, age, city))
+  }
+
+  let assert Ok(#(name, age, city)) = json.parse(json_string, person_decoder)
+  assert name == "John Smith"
+  assert age == 30
+  assert city == "Paris"
+}
+
+pub fn reasoning_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("SYNTHETIC_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new(
+      "https://api.synthetic.new/openai/v1",
+      api_key,
+      thinking.Generic,
+    )
+
+  let chat =
+    starlet.chat(client, "hf:moonshotai/Kimi-K2-Thinking")
+    |> openai_compat.with_reasoning(thinking.EffortHigh)
+    |> starlet.user("What is the sum of all prime numbers between 1 and 20?")
+
+  let assert Ok(#(chat, turn1)) = starlet.send(chat)
+  let response1 = starlet.text(turn1)
+
+  assert string.length(response1) > 0
+  let assert Some(_) = openai_compat.thinking(turn1)
+
+  let chat =
+    chat
+    |> starlet.user("Now multiply that result by 3.")
+
+  let assert Ok(#(_chat, turn2)) = starlet.send(chat)
+  let response2 = starlet.text(turn2)
+
+  assert string.length(response2) > 0
+  let assert Some(_) = openai_compat.thinking(turn2)
+  Nil
+}

--- a/test/integration/together_test.gleam
+++ b/test/integration/together_test.gleam
@@ -1,0 +1,159 @@
+import envoy
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{Some}
+import gleam/result
+import gleam/string
+import jscheam/schema
+import starlet
+import starlet/openai_compat
+import starlet/openai_compat/thinking
+import starlet/tool
+import unitest
+
+pub fn simple_chat_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("TOGETHER_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new("https://api.together.xyz/v1", api_key, thinking.Together)
+
+  let chat =
+    starlet.chat(client, "moonshotai/Kimi-K2-Thinking")
+    |> starlet.system("Reply with exactly one word.")
+    |> starlet.user("Say hello")
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let response = starlet.text(turn)
+
+  assert string.length(response) > 0
+}
+
+pub fn tool_calling_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("TOGETHER_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new("https://api.together.xyz/v1", api_key, thinking.Together)
+
+  let weather_tool =
+    tool.function(
+      name: "get_weather",
+      description: "Get the current weather for a city",
+      parameters: json.object([
+        #("type", json.string("object")),
+        #(
+          "properties",
+          json.object([
+            #(
+              "city",
+              json.object([
+                #("type", json.string("string")),
+                #("description", json.string("The city name")),
+              ]),
+            ),
+          ]),
+        ),
+        #("required", json.array(["city"], json.string)),
+      ]),
+    )
+
+  let chat =
+    starlet.chat(client, "moonshotai/Kimi-K2-Thinking")
+    |> openai_compat.with_reasoning(thinking.EffortMedium)
+    |> starlet.system(
+      "You are a helpful assistant. Use the get_weather tool when asked about weather. After tool results, reply with a short sentence.",
+    )
+    |> starlet.with_tools([weather_tool])
+    |> starlet.user("What is the weather in Paris?")
+
+  let assert Ok(starlet.ToolCall(chat:, turn: _, calls:)) = starlet.step(chat)
+  let assert [call] = calls
+  assert call.name == "get_weather"
+
+  let tool_result =
+    tool.success(
+      call,
+      json.object([
+        #("temperature", json.int(22)),
+        #("condition", json.string("sunny")),
+      ]),
+    )
+  let chat = starlet.with_tool_results(chat, [tool_result])
+
+  let assert Ok(starlet.Done(chat: _, turn:)) = starlet.step(chat)
+  let response = starlet.text(turn)
+
+  assert string.length(response) > 0
+}
+
+pub fn json_output_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("TOGETHER_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new("https://api.together.xyz/v1", api_key, thinking.Together)
+
+  let person_schema =
+    schema.object([
+      schema.prop("name", schema.string()),
+      schema.prop("age", schema.integer()),
+      schema.prop("city", schema.string()),
+    ])
+    |> schema.disallow_additional_props()
+
+  let chat =
+    starlet.chat(client, "moonshotai/Kimi-K2-Thinking")
+    |> starlet.system(
+      "You are a helpful assistant that extracts structured data.",
+    )
+    |> starlet.with_json_output(person_schema)
+    |> starlet.user(
+      "Extract the person info: John Smith is 30 years old and lives in Paris.",
+    )
+
+  let assert Ok(#(_chat, turn)) = starlet.send(chat)
+  let json_string = starlet.json(turn)
+
+  let person_decoder = {
+    use name <- decode.field("name", decode.string)
+    use age <- decode.field("age", decode.int)
+    use city <- decode.field("city", decode.string)
+    decode.success(#(name, age, city))
+  }
+
+  let assert Ok(#(name, age, city)) = json.parse(json_string, person_decoder)
+  assert name == "John Smith"
+  assert age == 30
+  assert city == "Paris"
+}
+
+pub fn reasoning_test() -> Nil {
+  use <- unitest.tag("integration")
+
+  let api_key = envoy.get("TOGETHER_API_KEY") |> result.unwrap("")
+  let client =
+    openai_compat.new("https://api.together.xyz/v1", api_key, thinking.Together)
+
+  let chat =
+    starlet.chat(client, "moonshotai/Kimi-K2-Thinking")
+    |> openai_compat.with_reasoning(thinking.EffortMedium)
+    |> starlet.user("What is the sum of all prime numbers between 1 and 20?")
+
+  let assert Ok(#(chat, turn1)) = starlet.send(chat)
+  let response1 = starlet.text(turn1)
+
+  assert string.length(response1) > 0
+  let assert Some(_) = openai_compat.thinking(turn1)
+
+  let chat =
+    chat
+    |> starlet.user("Now multiply that result by 3.")
+
+  let assert Ok(#(_chat, turn2)) = starlet.send(chat)
+  let response2 = starlet.text(turn2)
+
+  assert string.length(response2) > 0
+  let assert Some(_) = openai_compat.thinking(turn2)
+  Nil
+}

--- a/test/starlet/openai_compat_test.gleam
+++ b/test/starlet/openai_compat_test.gleam
@@ -1,0 +1,866 @@
+import birdie
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{None, Some}
+import starlet.{
+  AssistantMessage, Chat, Decode, Request, ToolResultMessage, UserMessage, chat,
+}
+import starlet/openai_compat
+import starlet/openai_compat/thinking
+import starlet/tool
+
+fn default_ext() -> openai_compat.Ext {
+  openai_compat.Ext(
+    dialect: thinking.Tags,
+    thinking_config: None,
+    thinking: None,
+    thinking_by_index: [],
+    interleaved_thinking: True,
+  )
+}
+
+pub fn encode_simple_request_test() {
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [UserMessage("Hello")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode simple request")
+}
+
+pub fn encode_request_with_system_prompt_test() {
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: Some("Be helpful"),
+      messages: [UserMessage("Hello")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with system prompt")
+}
+
+pub fn encode_request_with_options_test() {
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [UserMessage("Hello")],
+      tools: [],
+      temperature: Some(0.7),
+      max_tokens: Some(1000),
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with options")
+}
+
+pub fn encode_request_with_conversation_test() {
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [
+        UserMessage("Hello"),
+        AssistantMessage("Hi!", []),
+        UserMessage("How are you?"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with conversation")
+}
+
+pub fn encode_request_with_tools_test() {
+  let weather_tool =
+    tool.function(
+      name: "get_weather",
+      description: "Get the current weather for a city",
+      parameters: json.object([
+        #("type", json.string("object")),
+        #(
+          "properties",
+          json.object([
+            #("city", json.object([#("type", json.string("string"))])),
+          ]),
+        ),
+        #("required", json.array(["city"], json.string)),
+      ]),
+    )
+
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [UserMessage("What's the weather in Paris?")],
+      tools: [weather_tool],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with tools")
+}
+
+pub fn encode_request_with_json_schema_test() {
+  let schema =
+    json.object([
+      #("type", json.string("object")),
+      #(
+        "properties",
+        json.object([
+          #("name", json.object([#("type", json.string("string"))])),
+        ]),
+      ),
+    ])
+
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [UserMessage("Tell me about France")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: Some(schema),
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with json schema")
+}
+
+pub fn decode_simple_response_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #("content", json.string("Hello there!")),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, default_ext())
+  assert response.text == "Hello there!"
+  assert thinking == None
+}
+
+pub fn decode_response_with_tool_calls_test() {
+  let args = json.object([#("city", json.string("Paris"))]) |> json.to_string
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #("content", json.string("")),
+                #(
+                  "tool_calls",
+                  json.preprocessed_array([
+                    json.object([
+                      #("id", json.string("call_abc")),
+                      #("type", json.string("function")),
+                      #(
+                        "function",
+                        json.object([
+                          #("name", json.string("get_weather")),
+                          #("arguments", json.string(args)),
+                        ]),
+                      ),
+                    ]),
+                  ]),
+                ),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let assert Ok(#(response, _thinking)) =
+    openai_compat.decode_response(body, default_ext())
+  assert response.text == ""
+
+  let assert [call] = response.tool_calls
+  assert call.id == "call_abc"
+  assert call.name == "get_weather"
+  let assert Ok("Paris") =
+    decode.run(call.arguments, decode.at(["city"], decode.string))
+}
+
+pub fn decode_invalid_json_returns_error_test() {
+  let body = "not json"
+  let assert Error(Decode(_)) =
+    openai_compat.decode_response(body, default_ext())
+}
+
+pub fn decode_empty_choices_test() {
+  let body =
+    json.object([#("choices", json.preprocessed_array([]))])
+    |> json.to_string
+
+  let assert Ok(#(response, _thinking)) =
+    openai_compat.decode_response(body, default_ext())
+  assert response.text == ""
+  assert response.tool_calls == []
+}
+
+pub fn encode_request_with_reasoning_effort_test() {
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [UserMessage("Solve step by step")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  let config =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortHigh)
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Generic,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with reasoning_effort high")
+}
+
+pub fn encode_request_with_reasoning_format_test() {
+  let req =
+    Request(
+      model: "llama-3.3-70b",
+      system_prompt: None,
+      messages: [UserMessage("Solve step by step")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  let config = thinking.config_for_dialect(thinking.Groq, thinking.EffortHigh)
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Groq,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with reasoning_format parsed")
+}
+
+pub fn encode_request_with_disable_reasoning_test() {
+  let req =
+    Request(
+      model: "glm-z1-air",
+      system_prompt: None,
+      messages: [UserMessage("Quick answer")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  let config =
+    thinking.Config(
+      request: thinking.RequestDisable(True),
+      response: thinking.ResponseNone,
+      context: thinking.ContextDoNotSend,
+      strip_from_content: False,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with disable_reasoning")
+}
+
+pub fn encode_request_with_zai_thinking_test() {
+  let req =
+    Request(
+      model: "deepseek-reasoner",
+      system_prompt: None,
+      messages: [UserMessage("Think about this")],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  let config =
+    thinking.Config(
+      request: thinking.RequestZai(True),
+      response: thinking.ResponseNone,
+      context: thinking.ContextDoNotSend,
+      strip_from_content: False,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with zai thinking enabled")
+}
+
+pub fn decode_response_with_reasoning_content_field_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #("content", json.string("The answer is 42.")),
+                #(
+                  "reasoning_content",
+                  json.string("Let me think... I need to calculate..."),
+                ),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let config =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortHigh)
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Generic,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, ext)
+  assert response.text == "The answer is 42."
+  assert thinking == Some("Let me think... I need to calculate...")
+}
+
+pub fn decode_response_with_reasoning_field_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #("content", json.string("The answer is 42.")),
+                #("reasoning", json.string("Step 1: analyze the question...")),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let config = thinking.config_for_dialect(thinking.Groq, thinking.EffortHigh)
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Groq,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, ext)
+  assert response.text == "The answer is 42."
+  assert thinking == Some("Step 1: analyze the question...")
+}
+
+pub fn decode_response_with_think_tags_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #(
+                  "content",
+                  json.string(
+                    "<think>Let me think about this...</think>The answer is 42.",
+                  ),
+                ),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let config = thinking.config_for_dialect(thinking.Tags, thinking.EffortHigh)
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, ext)
+  assert response.text == "The answer is 42."
+  assert thinking == Some("Let me think about this...")
+}
+
+pub fn decode_response_with_think_tags_no_strip_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #(
+                  "content",
+                  json.string(
+                    "<think>Let me think about this...</think>The answer is 42.",
+                  ),
+                ),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let config =
+    thinking.Config(
+      request: thinking.RequestNone,
+      response: thinking.ResponseThinkTags,
+      context: thinking.ContextDoNotSend,
+      strip_from_content: False,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, ext)
+  assert response.text
+    == "<think>Let me think about this...</think>The answer is 42."
+  assert thinking == Some("Let me think about this...")
+}
+
+pub fn decode_response_without_thinking_config_ignores_fields_test() {
+  let body =
+    json.object([
+      #(
+        "choices",
+        json.preprocessed_array([
+          json.object([
+            #(
+              "message",
+              json.object([
+                #("role", json.string("assistant")),
+                #("content", json.string("The answer is 42.")),
+                #("reasoning_content", json.string("This should be ignored")),
+              ]),
+            ),
+          ]),
+        ]),
+      ),
+    ])
+    |> json.to_string
+
+  let assert Ok(#(response, thinking)) =
+    openai_compat.decode_response(body, default_ext())
+  assert response.text == "The answer is 42."
+  assert thinking == None
+}
+
+pub fn encode_request_with_tool_calls_test() {
+  let arguments =
+    json.object([#("city", json.string("Paris"))])
+    |> json.to_string
+  let assert Ok(arguments) = json.parse(arguments, decode.dynamic)
+  let tool_call = tool.Call(id: "call_123", name: "get_weather", arguments:)
+
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [
+        UserMessage("What's the weather in Paris?"),
+        AssistantMessage("", [tool_call]),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with tool calls")
+}
+
+pub fn encode_request_with_tool_result_test() {
+  let arguments =
+    json.object([#("city", json.string("Paris"))])
+    |> json.to_string
+  let assert Ok(arguments) = json.parse(arguments, decode.dynamic)
+  let tool_call = tool.Call(id: "call_123", name: "get_weather", arguments:)
+  let tool_result =
+    json.object([
+      #("temp", json.int(22)),
+      #("condition", json.string("sunny")),
+    ])
+    |> json.to_string
+
+  let req =
+    Request(
+      model: "gpt-4o",
+      system_prompt: None,
+      messages: [
+        UserMessage("What's the weather in Paris?"),
+        AssistantMessage("", [tool_call]),
+        ToolResultMessage("call_123", "get_weather", tool_result),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, default_ext())
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with tool result")
+}
+
+pub fn encode_request_with_context_send_as_field_test() {
+  let config =
+    thinking.Config(
+      request: thinking.RequestEffort("high"),
+      response: thinking.ResponseFields(["reasoning_content"]),
+      context: thinking.ContextSendAsField("reasoning_content"),
+      strip_from_content: False,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [
+        UserMessage("First question"),
+        AssistantMessage("First answer", []),
+        UserMessage("Follow up"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with context send as field")
+}
+
+pub fn encode_request_with_context_send_with_tags_test() {
+  let config =
+    thinking.Config(
+      request: thinking.RequestNone,
+      response: thinking.ResponseThinkTags,
+      context: thinking.ContextSendWithTags,
+      strip_from_content: True,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [
+        UserMessage("First question\nWith detail"),
+        AssistantMessage("First answer with \"quotes\"", []),
+        UserMessage("Follow up"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request with context send with tags")
+}
+
+pub fn encode_request_with_context_send_with_tags_preserves_history_test() {
+  let config =
+    thinking.Config(
+      request: thinking.RequestNone,
+      response: thinking.ResponseThinkTags,
+      context: thinking.ContextSendWithTags,
+      strip_from_content: True,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Tags,
+      thinking_config: Some(config),
+      thinking: None,
+      thinking_by_index: [],
+      interleaved_thinking: True,
+    )
+
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [
+        UserMessage("First question"),
+        AssistantMessage("<think>Old reasoning</think>First answer", []),
+        UserMessage("Second question"),
+        AssistantMessage("Second answer", []),
+        UserMessage("Follow up"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request preserves thinking history")
+}
+
+pub fn encode_request_preserves_reasoning_context_across_turns_test() {
+  let config =
+    thinking.Config(
+      request: thinking.RequestEffort("high"),
+      response: thinking.ResponseFields(["reasoning_content"]),
+      context: thinking.ContextSendAsField("reasoning_content"),
+      strip_from_content: False,
+    )
+  let ext =
+    openai_compat.Ext(
+      dialect: thinking.Together,
+      thinking_config: Some(config),
+      thinking: Some("Reasoning two"),
+      thinking_by_index: [#(3, "Reasoning two"), #(1, "Reasoning one")],
+      interleaved_thinking: True,
+    )
+
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [
+        UserMessage("First question"),
+        AssistantMessage("First answer", []),
+        UserMessage("Second question"),
+        AssistantMessage("Second answer", []),
+        UserMessage("Follow up"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request preserves reasoning context")
+}
+
+pub fn encode_request_without_interleaved_thinking_omits_history_test() {
+  let config =
+    thinking.Config(
+      request: thinking.RequestEffort("high"),
+      response: thinking.ResponseFields(["reasoning_content"]),
+      context: thinking.ContextSendAsField("reasoning_content"),
+      strip_from_content: False,
+    )
+  let client =
+    openai_compat.new("https://example.com", "test", thinking.Together)
+  let chat =
+    chat(client, "deepseek-r1")
+    |> openai_compat.with_thinking_config(config)
+    |> openai_compat.with_interleaved_thinking
+    |> openai_compat.without_interleaved_thinking
+  let Chat(ext:, ..) = chat
+
+  let req =
+    Request(
+      model: "deepseek-r1",
+      system_prompt: None,
+      messages: [
+        UserMessage("First question"),
+        AssistantMessage("First answer", []),
+        UserMessage("Follow up"),
+      ],
+      tools: [],
+      temperature: None,
+      max_tokens: None,
+      json_schema: None,
+      timeout_ms: 60_000,
+    )
+
+  openai_compat.encode_request(req, ext)
+  |> json.to_string
+  |> birdie.snap("openai_compat encode request without interleaved thinking")
+}
+
+pub fn config_for_dialect_test() {
+  let fireworks_high =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortHigh)
+  assert fireworks_high.request == thinking.RequestEffort("high")
+
+  let fireworks_medium =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortMedium)
+  assert fireworks_medium.request == thinking.RequestEffort("medium")
+
+  let fireworks_low =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortLow)
+  assert fireworks_low.request == thinking.RequestEffort("low")
+
+  let fireworks_none =
+    thinking.config_for_dialect(thinking.Generic, thinking.EffortNone)
+  assert fireworks_none.request == thinking.RequestNone
+
+  let together_high =
+    thinking.config_for_dialect(thinking.Together, thinking.EffortHigh)
+  assert together_high.request == thinking.RequestEffort("high")
+
+  let groq_high =
+    thinking.config_for_dialect(thinking.Groq, thinking.EffortHigh)
+  assert groq_high.request == thinking.RequestFormat("parsed")
+
+  let groq_none =
+    thinking.config_for_dialect(thinking.Groq, thinking.EffortNone)
+  assert groq_none.request == thinking.RequestFormat("hidden")
+
+  let cerebras =
+    thinking.config_for_dialect(thinking.Cerebras, thinking.EffortHigh)
+  assert cerebras.request == thinking.RequestFormat("parsed")
+
+  let llama_cpp =
+    thinking.config_for_dialect(thinking.LlamaCpp, thinking.EffortHigh)
+  assert llama_cpp.request == thinking.RequestNone
+
+  let generic = thinking.config_for_dialect(thinking.Tags, thinking.EffortHigh)
+  assert generic.response == thinking.ResponseThinkTags
+  assert generic.strip_from_content == True
+}


### PR DESCRIPTION
Adds a new provider module for OpenAI-compatible APIs (/v1/chat/completions) supported by Synthetic, Together AI, Fireworks, Groq, vLLM, llama.cpp, and others.

Includes a dialect system for reasoning/thinking support:
- Generic, Together AI, Groq, Cerebras, LlamaCpp, and Tags dialects
- Configurable effort levels (low/medium/high) and context handling
- Provider-local interleaved thinking via Ext.thinking_by_index

Includes integration tests for Synthetic, Fireworks, and Together AI.

Fixes: #1 

---

Leaving as a draft for now because I want to try consuming it from my own project or a script to see whether the API for all the different providers across multiple turns is right.